### PR TITLE
Fixed testserver and wazuh converter errors

### DIFF
--- a/idmefv2/connectors/testserver/__main__.py
+++ b/idmefv2/connectors/testserver/__main__.py
@@ -5,7 +5,7 @@ import argparse
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import logging
 import jsonschema
-import idmefv2
+from idmefv2.message import Message, SerializedMessage
 
 
 class IDMEFv2RequestHandler(BaseHTTPRequestHandler):
@@ -54,8 +54,8 @@ class IDMEFv2RequestHandler(BaseHTTPRequestHandler):
         status = 200
         response_data = None
         try:
-            payload = idmefv2.SerializedMessage('application/json', post_data)
-            idmefv2.Message.unserialize(payload)
+            payload = SerializedMessage('application/json', post_data)
+            Message.unserialize(payload)
         except jsonschema.exceptions.ValidationError as e:
             logging.error(e.message)
             status = 500

--- a/idmefv2/connectors/wazuh/wazuhconverter.py
+++ b/idmefv2/connectors/wazuh/wazuhconverter.py
@@ -57,7 +57,7 @@ class WazuhConverter(JSONConverter):
             "IP": "$.agent.ip",
             "Name": "$.agent.name",
             "Model": "Wazuh",
-            "Type": "Cyber",
+            "Type": ["Cyber"],
             "Category": [
                 "HIDS"
             ],
@@ -74,7 +74,7 @@ class WazuhConverter(JSONConverter):
                 "FileName": "$.syscheck.path",
                 "Hash": [
                     ((lambda h : 'sha-1:' + h), "$.syscheck.sha1_after"),
-                    ((lambda h : 'sha-256::' + h), "$.syscheck.sha256_after"),
+                    ((lambda h : 'sha-256:' + h), "$.syscheck.sha256_after"),
                 ],
                 "Size": (int, "$.syscheck.size_after"),
             },


### PR DESCRIPTION
Fixed idmefv2 package error for testserver, fixed validation errors for wazuhconverter.

Inside the main file of testserver, solved the error: AttributeError: module 'idmefv2' has no attribute 'SerializedMessage'
This error seems to be caused by the fact that the package used for serialization has the same name of the parent module of the testserver.

Inside the wazuhconverter.py file, solved the errors:
-ERROR:root:'Cyber' is not of type 'array'
-ERROR:root:'sha-256::b1c2751ab1b0d9f67cd2c629aa87cde994ce0579c104fdf258865e31af0aaf60' does not match '^[a-zA-Z0-9-]+:([a-fA-F0-9]{2})+$' 
These errors appeared while validating the newly converted IDMEFv2 messages using the testserver.