### PR TITLE
idmefv2 lifecycle by UUID

### DIFF
--- a/idmefv2/connectors/jsonconverter.py
+++ b/idmefv2/connectors/jsonconverter.py
@@ -2,6 +2,7 @@
     Generic JSON to JSON converter
 '''
 import jsonpath_ng as jsonpath
+from .idmefv2funs import idmefv2_uuid
 
 class JSONConverter:
     '''
@@ -32,6 +33,40 @@ class JSONConverter:
 
     See jsonconverter_test.py for examples
     '''
+
+    '''
+    A dict mapping event IDs to IDMEFv2 message IDs, used to avoid generating multiple IDMEF messages identifier for the same event
+    (for alert lifecycle management)
+    '''
+    message_ids = {}
+
+    def _idmefv2_uuid(self, identifier: any) -> str:
+        '''
+        Get the IDMEFv2 message ID for a given event identifier, generating a new one if not already present
+
+        Returns:
+            str: a new UUID version 4
+        '''
+        if (identifier in JSONConverter.message_ids):
+            return JSONConverter.message_ids[identifier]
+        new_id = idmefv2_uuid()
+        JSONConverter.message_ids[identifier] = new_id
+        return new_id
+
+    def _idemfv2_uuid_terminate(self, identifier: any) -> str:
+        '''
+        Terminate the IDMEFv2 message ID for a given event identifier, i.e. remove it from the dict of message IDs
+
+        Args:
+            identifier (any): the event identifier
+        '''
+        if (identifier in JSONConverter.message_ids):
+            uuid = JSONConverter.message_ids[identifier]
+            del JSONConverter.message_ids[identifier]
+            return uuid
+        # if identifier is not in the dict, generate a new UUID and return it, should not happen in normal conditions
+        return idmefv2_uuid()
+
     @staticmethod
     def __compile_template(template: any):
         if isinstance(template, str) and template.startswith('$'):

--- a/idmefv2/connectors/motion/motionconverter.py
+++ b/idmefv2/connectors/motion/motionconverter.py
@@ -93,7 +93,9 @@ class MotionPictureSaveConverter(JSONConverter):
     }
 
     def __init__(self):
-        super().__init__(MotionPictureSaveConverter.IDMEFV2_TEMPLATE)
+        template = MotionPictureSaveConverter.IDMEFV2_TEMPLATE
+        template['ID'] = (self._idmefv2_uuid, '$.event_id')
+        super().__init__(template)
 
     def filter(self, src: dict) -> bool:
         return src.get('event_name') == "picture_save"
@@ -140,7 +142,9 @@ class MotionCameraLostConverter(JSONConverter):
     }
 
     def __init__(self):
-        super().__init__(MotionEventStartConverter.IDMEFV2_TEMPLATE)
+        template = self.IDMEFV2_TEMPLATE
+        template['ID'] = (self._idmefv2_uuid, '$.event_id')
+        super().__init__(template)
 
     def filter(self, src: dict) -> bool:
         return src.get('event_name') == "camera_lost"
@@ -186,7 +190,8 @@ class MotionEventStartConverter(JSONConverter):
 
     def __init__(self, stream_port: int):
         self._stream_port = stream_port
-        template = MotionEventStartConverter.IDMEFV2_TEMPLATE
+        template = self.IDMEFV2_TEMPLATE
+        template['ID'] = (self._idmefv2_uuid, '$.event_id')
         template['Attachment'][0]['ExternalURI'] = [(get_stream_uri, "$.camera_id", stream_port)]
         super().__init__(template)
 
@@ -228,7 +233,9 @@ class MotionEventEndConverter(JSONConverter):
     }
 
     def __init__(self):
-        super().__init__(MotionEventStartConverter.IDMEFV2_TEMPLATE)
+        template = self.IDMEFV2_TEMPLATE
+        template['ID'] = (self._idemfv2_uuid_terminate, '$.event_id')
+        super().__init__(template)
 
     def filter(self, src: dict) -> bool:
         return src.get('event_name') == "event_end"
@@ -273,7 +280,9 @@ class MotionMovieEndConverter(JSONConverter):
     }
 
     def __init__(self):
-        super().__init__(MotionEventStartConverter.IDMEFV2_TEMPLATE)
+        template = self.IDMEFV2_TEMPLATE
+        template['ID'] = (self._idmefv2_uuid, '$.event_id')
+        super().__init__(template)
 
     def filter(self, src: dict) -> bool:
         return src.get('event_name') == "movie_end"


### PR DESCRIPTION
Alert lifecycle handling 
  - unique ID for a single alert
 
Keep in memory a dictionnary of event ID : IDMEFv2 UUID until the end of an alert